### PR TITLE
Add date sorting chips and improve frontend tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
     // Coroutines
     implementation libs.kotlinx.coroutines.android
+    testImplementation libs.kotlinx.coroutines.test
 
     // ViewModel
     implementation libs.androidx.lifecycle.viewmodel.compose

--- a/app/src/androidTest/java/com/example/frontend/ui/dashboard/DashboardScreenTest.kt
+++ b/app/src/androidTest/java/com/example/frontend/ui/dashboard/DashboardScreenTest.kt
@@ -1,0 +1,65 @@
+package com.example.frontend.ui.dashboard
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.example.frontend.ui.theme.FrontendTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@Suppress("TestFunctionName")
+class DashboardScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun DashboardScreen_displaysUserInfo_andSwitchesTabs() {
+        composeTestRule.setContent {
+            FrontendTheme {
+                DashboardScreen(
+                    userName = "Alex",
+                    userRole = "ADMIN",
+                    onSignOut = { },
+                    homeContent = { _, _ -> Text("Home Slot") },
+                    reservationsContent = { _ -> Text("Reservations Slot") }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Alex").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Role: ADMIN").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Home Slot").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("My Reservations").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Reservations Slot").assertIsDisplayed()
+    }
+
+    @Test
+    fun DashboardScreen_signOutButtonInvokesCallback() {
+        var signOutClicked = false
+
+        composeTestRule.setContent {
+            FrontendTheme {
+                DashboardScreen(
+                    userName = "Alex",
+                    userRole = "ADMIN",
+                    onSignOut = { signOutClicked = true },
+                    homeContent = { _, _ -> Text("Home Slot") },
+                    reservationsContent = { _ -> Text("Reservations Slot") }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("SignOut").performClick()
+        composeTestRule.waitForIdle()
+
+        assertTrue(signOutClicked)
+    }
+}

--- a/app/src/androidTest/java/com/example/frontend/ui/home/AddEditEventDialogTest.kt
+++ b/app/src/androidTest/java/com/example/frontend/ui/home/AddEditEventDialogTest.kt
@@ -1,0 +1,83 @@
+package com.example.frontend.ui.home
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.example.frontend.model.CreateEventRequest
+import com.example.frontend.model.EventCategory
+import com.example.frontend.model.EventResponse
+import com.example.frontend.ui.theme.FrontendTheme
+import java.math.BigDecimal
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+
+@Suppress("TestFunctionName")
+class AddEditEventDialogTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun AddEditEventDialog_displaysFieldsAndCategoryChips() {
+        composeTestRule.setContent {
+            FrontendTheme {
+                AddEditEventDialog(
+                    onDismiss = { },
+                    onConfirm = { }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Add Event").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Description").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Date (yyyy-MM-ddTHH:mm:ss)").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Location").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Category").assertIsDisplayed()
+        composeTestRule.onNodeWithText("MOVIE").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Save").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cancel").assertIsDisplayed()
+    }
+
+    @Test
+    fun AddEditEventDialog_saveEmitsFilledRequest() {
+        val existingEvent = EventResponse(
+            id = 4L,
+            title = "Old Title",
+            description = "Old description",
+            date = "2026-04-12T10:00:00",
+            location = "Old Hall",
+            category = EventCategory.MOVIE,
+            capacity = 50,
+            price = BigDecimal("12.50"),
+            availableSeats = 10
+        )
+        var capturedRequest: CreateEventRequest? = null
+
+        composeTestRule.setContent {
+            FrontendTheme {
+                AddEditEventDialog(
+                    existingEvent = existingEvent,
+                    onDismiss = { },
+                    onConfirm = { capturedRequest = it }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Save").performClick()
+        composeTestRule.waitForIdle()
+
+        assertNotNull(capturedRequest)
+        assertEquals(existingEvent.title, capturedRequest?.title)
+        assertEquals(existingEvent.description, capturedRequest?.description)
+        assertEquals(existingEvent.date, capturedRequest?.date)
+        assertEquals(existingEvent.location, capturedRequest?.location)
+        assertEquals(existingEvent.category, capturedRequest?.category)
+        assertEquals(existingEvent.capacity, capturedRequest?.capacity)
+        assertEquals(existingEvent.price, capturedRequest?.price)
+    }
+}

--- a/app/src/androidTest/java/com/example/frontend/ui/home/EventDetailScreenTest.kt
+++ b/app/src/androidTest/java/com/example/frontend/ui/home/EventDetailScreenTest.kt
@@ -1,0 +1,142 @@
+package com.example.frontend.ui.home
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.frontend.auth.TokenStorage
+import com.example.frontend.model.EventCategory
+import com.example.frontend.model.EventResponse
+import com.example.frontend.model.ReservationResponse
+import com.example.frontend.model.ReservationStatus
+import com.example.frontend.repository.EventRepository
+import com.example.frontend.repository.ReservationRepository
+import com.example.frontend.ui.theme.FrontendTheme
+import java.math.BigDecimal
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@Suppress("TestFunctionName")
+class EventDetailScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        TokenStorage.init(context)
+        TokenStorage.setUserId(99L)
+    }
+
+    @Test
+    fun EventDetailScreen_displaysEventDetails() {
+        val event = sampleEvent()
+
+        composeTestRule.setContent {
+            FrontendTheme {
+                EventDetailScreen(
+                    eventId = event.id,
+                    onBack = { },
+                    showSnackbar = { },
+                    eventRepository = FakeEventRepository(event),
+                    reservationRepository = FakeReservationRepository()
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Jazz Night").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Date: 2026-04-15T20:00:00").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Location: Main Hall").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Price: $25.00").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Available seats: 15").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Reserve").assertIsDisplayed()
+    }
+
+    @Test
+    fun EventDetailScreen_reserveButtonCallsRepositoryAndSnackbar() {
+        val event = sampleEvent()
+        val fakeReservationRepository = FakeReservationRepository()
+        var snackbarMessage: String? = null
+
+        composeTestRule.setContent {
+            FrontendTheme {
+                EventDetailScreen(
+                    eventId = event.id,
+                    onBack = { },
+                    showSnackbar = { snackbarMessage = it },
+                    eventRepository = FakeEventRepository(event),
+                    reservationRepository = fakeReservationRepository
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Reserve").performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(99L, fakeReservationRepository.lastUserId)
+        assertEquals(event.id, fakeReservationRepository.lastEventId)
+        assertEquals(1, fakeReservationRepository.lastNumberOfTickets)
+        assertEquals("Reserved!", snackbarMessage)
+        assertTrue(fakeReservationRepository.called)
+    }
+
+    private fun sampleEvent(): EventResponse {
+        return EventResponse(
+            id = 8L,
+            title = "Jazz Night",
+            description = "Live jazz",
+            date = "2026-04-15T20:00:00",
+            location = "Main Hall",
+            category = EventCategory.CONCERT,
+            capacity = 100,
+            price = BigDecimal("25.00"),
+            availableSeats = 15
+        )
+    }
+
+    private class FakeEventRepository(
+        private val event: EventResponse
+    ) : EventRepository() {
+        override suspend fun getEventById(id: Long): Result<EventResponse> = Result.success(event)
+    }
+
+    private class FakeReservationRepository : ReservationRepository() {
+        var called = false
+        var lastUserId: Long? = null
+        var lastEventId: Long? = null
+        var lastNumberOfTickets: Int? = null
+
+        override suspend fun createReservation(
+            userId: Long,
+            eventId: Long,
+            numberOfTickets: Int
+        ): Result<ReservationResponse> {
+            called = true
+            lastUserId = userId
+            lastEventId = eventId
+            lastNumberOfTickets = numberOfTickets
+            return Result.success(
+                ReservationResponse(
+                    id = 1L,
+                    userId = userId,
+                    userName = "User",
+                    eventId = eventId,
+                    eventTitle = "Jazz Night",
+                    status = ReservationStatus.CONFIRMED,
+                    reservedAt = "2026-04-15T20:01:00",
+                    confirmationCode = "ABC123",
+                    numberOfTickets = numberOfTickets
+                )
+            )
+        }
+    }
+}

--- a/app/src/androidTest/java/com/example/frontend/ui/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/example/frontend/ui/home/HomeScreenTest.kt
@@ -1,0 +1,122 @@
+package com.example.frontend.ui.home
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.example.frontend.model.EventCategory
+import com.example.frontend.model.EventResponse
+import com.example.frontend.repository.AdminRepository
+import com.example.frontend.repository.EventRepository
+import com.example.frontend.ui.theme.FrontendTheme
+import java.math.BigDecimal
+import org.junit.Rule
+import org.junit.Test
+
+@Suppress("TestFunctionName")
+class HomeScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun HomeScreen_displaysFilters_andShowsLoadedEvents() {
+        val homeViewModel = HomeViewModel(FakeEventRepository(sampleEvents()))
+        homeViewModel.searchQuery.value = "Alpha"
+        homeViewModel.selectedCategory.value = EventCategory.CONCERT
+        homeViewModel.dateSortOrder.value = DateSortOrder.ASCENDING
+
+        composeTestRule.setContent {
+            FrontendTheme {
+                HomeScreen(
+                    userRole = "USER",
+                    onEventClick = { },
+                    showSnackbar = { },
+                    viewModel = homeViewModel,
+                    adminViewModel = AdminViewModel(FakeAdminRepository())
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Search events...").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Ascending").assertIsDisplayed().assertIsSelected()
+        composeTestRule.onNodeWithText("Descending").assertIsDisplayed()
+        composeTestRule.onNodeWithText("All").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Alpha Concert").assertIsDisplayed()
+    }
+
+    @Test
+    fun HomeScreen_clickingDateSortChip_updatesSelection() {
+        val homeViewModel = HomeViewModel(FakeEventRepository(sampleEvents()))
+
+        composeTestRule.setContent {
+            FrontendTheme {
+                HomeScreen(
+                    userRole = "USER",
+                    onEventClick = { },
+                    showSnackbar = { },
+                    viewModel = homeViewModel,
+                    adminViewModel = AdminViewModel(FakeAdminRepository())
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Descending").assertIsSelected()
+
+        composeTestRule.onNodeWithText("Ascending").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Ascending").assertIsSelected()
+    }
+
+    private fun sampleEvents(): List<EventResponse> {
+        return listOf(
+            EventResponse(
+                id = 1L,
+                title = "Alpha Concert",
+                description = null,
+                date = "2026-04-12T10:00:00",
+                location = "Main Hall",
+                category = EventCategory.CONCERT,
+                capacity = 100,
+                price = BigDecimal("20.00"),
+                availableSeats = 40
+            ),
+            EventResponse(
+                id = 2L,
+                title = "Beta Movie",
+                description = null,
+                date = "2026-04-10T10:00:00",
+                location = "Cinema",
+                category = EventCategory.MOVIE,
+                capacity = 80,
+                price = BigDecimal("15.00"),
+                availableSeats = 30
+            ),
+            EventResponse(
+                id = 3L,
+                title = "Alpha Expo",
+                description = null,
+                date = "2026-04-11T10:00:00",
+                location = "Expo Center",
+                category = EventCategory.CONCERT,
+                capacity = 60,
+                price = BigDecimal("10.00"),
+                availableSeats = 20
+            )
+        )
+    }
+
+    private class FakeEventRepository(
+        private val events: List<EventResponse>
+    ) : EventRepository() {
+        override suspend fun getAllEvents(): Result<List<EventResponse>> = Result.success(events)
+    }
+
+    private class FakeAdminRepository : AdminRepository()
+}

--- a/app/src/main/java/com/example/frontend/repository/AdminRepository.kt
+++ b/app/src/main/java/com/example/frontend/repository/AdminRepository.kt
@@ -4,19 +4,19 @@ import com.example.frontend.model.CreateEventRequest
 import com.example.frontend.model.EventResponse
 import com.example.frontend.network.ApiClient
 
-class AdminRepository {
+open class AdminRepository {
 
     private val api = ApiClient.apiService
 
-    suspend fun createEvent(request: CreateEventRequest): Result<EventResponse> = runCatching {
+    open suspend fun createEvent(request: CreateEventRequest): Result<EventResponse> = runCatching {
         api.createEvent(request)
     }
 
-    suspend fun updateEvent(id: Long, request: CreateEventRequest): Result<EventResponse> = runCatching {
+    open suspend fun updateEvent(id: Long, request: CreateEventRequest): Result<EventResponse> = runCatching {
         api.updateEvent(id, request)
     }
 
-    suspend fun deleteEvent(id: Long): Result<Unit> = runCatching {
+    open suspend fun deleteEvent(id: Long): Result<Unit> = runCatching {
         api.deleteEvent(id)
     }
 }

--- a/app/src/main/java/com/example/frontend/repository/EventRepository.kt
+++ b/app/src/main/java/com/example/frontend/repository/EventRepository.kt
@@ -4,27 +4,27 @@ import com.example.frontend.model.EventCategory
 import com.example.frontend.model.EventResponse
 import com.example.frontend.network.ApiClient
 
-class EventRepository {
+open class EventRepository {
 
     private val api = ApiClient.apiService
 
-    suspend fun getAllEvents(): Result<List<EventResponse>> = runCatching {
+    open suspend fun getAllEvents(): Result<List<EventResponse>> = runCatching {
         api.getAllEvents()
     }
 
-    suspend fun getEventById(id: Long): Result<EventResponse> = runCatching {
+    open suspend fun getEventById(id: Long): Result<EventResponse> = runCatching {
         api.getEventById(id)
     }
 
-    suspend fun getEventsByCategory(category: EventCategory): Result<List<EventResponse>> = runCatching {
+    open suspend fun getEventsByCategory(category: EventCategory): Result<List<EventResponse>> = runCatching {
         api.getEventsByCategory(category)
     }
 
-    suspend fun getEventsByLocation(location: String): Result<List<EventResponse>> = runCatching {
+    open suspend fun getEventsByLocation(location: String): Result<List<EventResponse>> = runCatching {
         api.getEventsByLocation(location)
     }
 
-    suspend fun getEventsByDateRange(start: String, end: String): Result<List<EventResponse>> = runCatching {
+    open suspend fun getEventsByDateRange(start: String, end: String): Result<List<EventResponse>> = runCatching {
         api.getEventsByDateRange(start, end)
     }
 }

--- a/app/src/main/java/com/example/frontend/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/frontend/ui/dashboard/DashboardScreen.kt
@@ -40,7 +40,17 @@ import kotlinx.coroutines.launch
 fun DashboardScreen(
     userName: String,
     userRole: String,
-    onSignOut: () -> Unit
+    onSignOut: () -> Unit,
+    homeContent: @Composable (onEventClick: (Long) -> Unit, showSnackbar: (String) -> Unit) -> Unit = { onEventClick, showSnackbar ->
+        HomeScreen(
+            userRole = userRole,
+            onEventClick = onEventClick,
+            showSnackbar = showSnackbar
+        )
+    },
+    reservationsContent: @Composable (showSnackbar: (String) -> Unit) -> Unit = { showSnackbar ->
+        ReservationsScreen(showSnackbar = showSnackbar)
+    }
 ) {
     var selectedTab by remember { mutableIntStateOf(0) }
     var selectedEventId by remember { mutableStateOf<Long?>(null) }
@@ -102,14 +112,11 @@ fun DashboardScreen(
 
             Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
                 when (selectedTab) {
-                    0 -> HomeScreen(
-                        userRole = userRole,
-                        onEventClick = { selectedEventId = it },
-                        showSnackbar = { message -> scope.launch { snackbarHostState.showSnackbar(message) } }
+                    0 -> homeContent(
+                        { selectedEventId = it },
+                        { message -> scope.launch { snackbarHostState.showSnackbar(message) } }
                     )
-                    1 -> ReservationsScreen(
-                        showSnackbar = { message -> scope.launch { snackbarHostState.showSnackbar(message) } }
-                    )
+                    1 -> reservationsContent { message -> scope.launch { snackbarHostState.showSnackbar(message) } }
                 }
             }
         }

--- a/app/src/main/java/com/example/frontend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/frontend/ui/home/HomeScreen.kt
@@ -53,6 +53,7 @@ fun HomeScreen(
     val error by viewModel.errorMessage.collectAsState()
     val searchQuery by viewModel.searchQuery.collectAsState()
     val selectedCategory by viewModel.selectedCategory.collectAsState()
+    val dateSortOrder by viewModel.dateSortOrder.collectAsState()
 
     var showAddDialog by remember { mutableStateOf(false) }
     var eventToEdit by remember { mutableStateOf<EventResponse?>(null) }
@@ -132,6 +133,20 @@ fun HomeScreen(
                 contentPadding = PaddingValues(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
+                item {
+                    FilterChip(
+                        selected = dateSortOrder == DateSortOrder.ASCENDING,
+                        onClick = { viewModel.dateSortOrder.value = DateSortOrder.ASCENDING },
+                        label = { Text("Ascending") }
+                    )
+                }
+                item {
+                    FilterChip(
+                        selected = dateSortOrder == DateSortOrder.DESCENDING,
+                        onClick = { viewModel.dateSortOrder.value = DateSortOrder.DESCENDING },
+                        label = { Text("Descending") }
+                    )
+                }
                 item {
                     FilterChip(
                         selected = selectedCategory == null,

--- a/app/src/main/java/com/example/frontend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/frontend/ui/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.frontend.model.EventCategory
 import com.example.frontend.model.EventResponse
 import com.example.frontend.repository.EventRepository
+import java.time.LocalDateTime
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -27,15 +28,19 @@ class HomeViewModel(
 
     val searchQuery = MutableStateFlow("")
     val selectedCategory = MutableStateFlow<EventCategory?>(null)
+    val dateSortOrder = MutableStateFlow(DateSortOrder.DESCENDING)
 
     val events: StateFlow<List<EventResponse>> = combine(
-        _events, searchQuery, selectedCategory
-    ) { events, query, category ->
-        events.filter { event ->
-            (query.isBlank() || event.title.contains(query, ignoreCase = true) ||
-                    event.location.contains(query, ignoreCase = true)) &&
-                    (category == null || event.category == category)
-        }
+        _events, searchQuery, selectedCategory, dateSortOrder
+    ) { events, query, category, sortOrder ->
+        sortEventsByDate(
+            events.filter { event ->
+                (query.isBlank() || event.title.contains(query, ignoreCase = true) ||
+                        event.location.contains(query, ignoreCase = true)) &&
+                        (category == null || event.category == category)
+            },
+            sortOrder
+        )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     fun loadEvents() {
@@ -47,5 +52,21 @@ class HomeViewModel(
                 .onFailure { _errorMessage.value = it.message }
             _isLoading.value = false
         }
+    }
+}
+
+enum class DateSortOrder {
+    ASCENDING,
+    DESCENDING
+}
+
+internal fun sortEventsByDate(
+    events: List<EventResponse>,
+    sortOrder: DateSortOrder
+): List<EventResponse> {
+    val sortedEvents = events.sortedBy { LocalDateTime.parse(it.date) }
+    return when (sortOrder) {
+        DateSortOrder.ASCENDING -> sortedEvents
+        DateSortOrder.DESCENDING -> sortedEvents.reversed()
     }
 }

--- a/app/src/test/java/com/example/frontend/ui/home/AdminViewModelTest.kt
+++ b/app/src/test/java/com/example/frontend/ui/home/AdminViewModelTest.kt
@@ -1,0 +1,143 @@
+package com.example.frontend.ui.home
+
+import com.example.frontend.model.CreateEventRequest
+import com.example.frontend.model.EventCategory
+import com.example.frontend.model.EventResponse
+import com.example.frontend.repository.AdminRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.runTest
+import java.math.BigDecimal
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AdminViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun createEvent_successCallsRepositoryAndSuccessCallback() = runTest {
+        val repository = FakeAdminRepository(
+            createResult = Result.success(sampleEventResponse())
+        )
+        val viewModel = AdminViewModel(repository)
+        val request = sampleRequest()
+        var successCalled = false
+        var errorMessage: String? = null
+
+        viewModel.createEvent(request, onSuccess = { successCalled = true }, onError = { errorMessage = it })
+        advanceUntilIdle()
+
+        assertTrue(successCalled)
+        assertNull(errorMessage)
+        assertEquals(request, repository.lastCreateRequest)
+    }
+
+    @Test
+    fun updateEvent_failureCallsErrorCallback() = runTest {
+        val repository = FakeAdminRepository(
+            updateResult = Result.failure(IllegalStateException("Update failed"))
+        )
+        val viewModel = AdminViewModel(repository)
+        val request = sampleRequest()
+        var successCalled = false
+        var errorMessage: String? = null
+
+        viewModel.updateEvent(7L, request, onSuccess = { successCalled = true }, onError = { errorMessage = it })
+        advanceUntilIdle()
+
+        assertFalse(successCalled)
+        assertEquals("Update failed", errorMessage)
+        assertEquals(7L, repository.lastUpdateId)
+        assertEquals(request, repository.lastUpdateRequest)
+    }
+
+    @Test
+    fun deleteEvent_successCallsSuccessCallback() = runTest {
+        val repository = FakeAdminRepository(deleteResult = Result.success(Unit))
+        val viewModel = AdminViewModel(repository)
+        var successCalled = false
+        var errorMessage: String? = null
+
+        viewModel.deleteEvent(5L, onSuccess = { successCalled = true }, onError = { errorMessage = it })
+        advanceUntilIdle()
+
+        assertTrue(successCalled)
+        assertNull(errorMessage)
+        assertEquals(5L, repository.lastDeleteId)
+    }
+
+    private fun sampleRequest(): CreateEventRequest {
+        return CreateEventRequest(
+            title = "Concert Night",
+            description = "Live music",
+            date = "2026-04-15T20:00:00",
+            location = "Main Hall",
+            category = EventCategory.CONCERT,
+            capacity = 120,
+            price = BigDecimal("49.99")
+        )
+    }
+
+    private fun sampleEventResponse(): EventResponse {
+        return EventResponse(
+            id = 1L,
+            title = "Concert Night",
+            description = "Live music",
+            date = "2026-04-15T20:00:00",
+            location = "Main Hall",
+            category = EventCategory.CONCERT,
+            capacity = 120,
+            price = BigDecimal("49.99"),
+            availableSeats = 60
+        )
+    }
+
+    private class FakeAdminRepository(
+        private val createResult: Result<EventResponse> = Result.success(sampleEventResponse()),
+        private val updateResult: Result<EventResponse> = Result.success(sampleEventResponse()),
+        private val deleteResult: Result<Unit> = Result.success(Unit)
+    ) : AdminRepository() {
+
+        var lastCreateRequest: CreateEventRequest? = null
+        var lastUpdateId: Long? = null
+        var lastUpdateRequest: CreateEventRequest? = null
+        var lastDeleteId: Long? = null
+
+        override suspend fun createEvent(request: CreateEventRequest): Result<EventResponse> {
+            lastCreateRequest = request
+            return createResult
+        }
+
+        override suspend fun updateEvent(id: Long, request: CreateEventRequest): Result<EventResponse> {
+            lastUpdateId = id
+            lastUpdateRequest = request
+            return updateResult
+        }
+
+        override suspend fun deleteEvent(id: Long): Result<Unit> {
+            lastDeleteId = id
+            return deleteResult
+        }
+    }
+}

--- a/app/src/test/java/com/example/frontend/ui/home/AdminViewModelTest.kt
+++ b/app/src/test/java/com/example/frontend/ui/home/AdminViewModelTest.kt
@@ -100,22 +100,12 @@ class AdminViewModelTest {
     }
 
     private fun sampleEventResponse(): EventResponse {
-        return EventResponse(
-            id = 1L,
-            title = "Concert Night",
-            description = "Live music",
-            date = "2026-04-15T20:00:00",
-            location = "Main Hall",
-            category = EventCategory.CONCERT,
-            capacity = 120,
-            price = BigDecimal("49.99"),
-            availableSeats = 60
-        )
+        return defaultEventResponse()
     }
 
     private class FakeAdminRepository(
-        private val createResult: Result<EventResponse> = Result.success(sampleEventResponse()),
-        private val updateResult: Result<EventResponse> = Result.success(sampleEventResponse()),
+        private val createResult: Result<EventResponse> = Result.success(defaultEventResponse()),
+        private val updateResult: Result<EventResponse> = Result.success(defaultEventResponse()),
         private val deleteResult: Result<Unit> = Result.success(Unit)
     ) : AdminRepository() {
 
@@ -140,4 +130,18 @@ class AdminViewModelTest {
             return deleteResult
         }
     }
+}
+
+private fun defaultEventResponse(): EventResponse {
+    return EventResponse(
+        id = 1L,
+        title = "Concert Night",
+        description = "Live music",
+        date = "2026-04-15T20:00:00",
+        location = "Main Hall",
+        category = EventCategory.CONCERT,
+        capacity = 120,
+        price = BigDecimal("49.99"),
+        availableSeats = 60
+    )
 }

--- a/app/src/test/java/com/example/frontend/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/frontend/ui/home/HomeViewModelTest.kt
@@ -2,11 +2,34 @@ package com.example.frontend.ui.home
 
 import com.example.frontend.model.EventCategory
 import com.example.frontend.model.EventResponse
+import com.example.frontend.repository.EventRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.runTest
 import java.math.BigDecimal
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun sortEventsByDate_sortsAscendingAndDescending() {
@@ -23,17 +46,61 @@ class HomeViewModelTest {
         assertEquals(listOf(1L, 3L, 2L), descending.map { it.id })
     }
 
+    @Test
+    fun loadEvents_filtersAndSortsBySearchCategoryAndDate() = runTest {
+        val repository = FakeEventRepository(
+            listOf(
+                event(id = 1L, title = "Alpha Night", date = "2026-04-12T10:00:00", category = EventCategory.MOVIE),
+                event(id = 2L, title = "Beta Night", date = "2026-04-10T10:00:00", category = EventCategory.CONCERT),
+                event(id = 3L, title = "Alpha Expo", date = "2026-04-11T10:00:00", category = EventCategory.MOVIE)
+            )
+        )
+        val viewModel = HomeViewModel(repository)
+
+        viewModel.loadEvents()
+        advanceUntilIdle()
+
+        assertEquals(listOf(1L, 3L, 2L), viewModel.events.value.map { it.id })
+
+        viewModel.searchQuery.value = "Alpha"
+        advanceUntilIdle()
+        assertEquals(listOf(1L, 3L), viewModel.events.value.map { it.id })
+
+        viewModel.selectedCategory.value = EventCategory.MOVIE
+        advanceUntilIdle()
+        assertEquals(listOf(1L, 3L), viewModel.events.value.map { it.id })
+
+        viewModel.dateSortOrder.value = DateSortOrder.ASCENDING
+        advanceUntilIdle()
+        assertEquals(listOf(3L, 1L), viewModel.events.value.map { it.id })
+    }
+
     private fun event(id: Long, date: String): EventResponse {
+        return event(id, "Event $id", date, EventCategory.CONCERT)
+    }
+
+    private fun event(
+        id: Long,
+        title: String,
+        date: String,
+        category: EventCategory
+    ): EventResponse {
         return EventResponse(
             id = id,
-            title = "Event $id",
+            title = title,
             description = null,
             date = date,
             location = "Main Hall",
-            category = EventCategory.CONCERT,
+            category = category,
             capacity = 100,
             price = BigDecimal.TEN,
             availableSeats = 50
         )
+    }
+
+    private class FakeEventRepository(
+        private val events: List<EventResponse>
+    ) : EventRepository() {
+        override suspend fun getAllEvents(): Result<List<EventResponse>> = Result.success(events)
     }
 }

--- a/app/src/test/java/com/example/frontend/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/frontend/ui/home/HomeViewModelTest.kt
@@ -1,0 +1,39 @@
+package com.example.frontend.ui.home
+
+import com.example.frontend.model.EventCategory
+import com.example.frontend.model.EventResponse
+import java.math.BigDecimal
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeViewModelTest {
+
+    @Test
+    fun sortEventsByDate_sortsAscendingAndDescending() {
+        val events = listOf(
+            event(id = 1L, date = "2026-04-12T10:00:00"),
+            event(id = 2L, date = "2026-04-10T10:00:00"),
+            event(id = 3L, date = "2026-04-11T10:00:00")
+        )
+
+        val ascending = sortEventsByDate(events, DateSortOrder.ASCENDING)
+        val descending = sortEventsByDate(events, DateSortOrder.DESCENDING)
+
+        assertEquals(listOf(2L, 3L, 1L), ascending.map { it.id })
+        assertEquals(listOf(1L, 3L, 2L), descending.map { it.id })
+    }
+
+    private fun event(id: Long, date: String): EventResponse {
+        return EventResponse(
+            id = id,
+            title = "Event $id",
+            description = null,
+            date = date,
+            location = "Main Hall",
+            category = EventCategory.CONCERT,
+            capacity = 100,
+            price = BigDecimal.TEN,
+            availableSeats = 50
+        )
+    }
+}

--- a/app/src/test/java/com/example/frontend/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/frontend/ui/home/HomeViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -56,6 +57,7 @@ class HomeViewModelTest {
             )
         )
         val viewModel = HomeViewModel(repository)
+        val collectorJob = backgroundScope.launch { viewModel.events.collect { } }
 
         viewModel.loadEvents()
         advanceUntilIdle()
@@ -73,6 +75,8 @@ class HomeViewModelTest {
         viewModel.dateSortOrder.value = DateSortOrder.ASCENDING
         advanceUntilIdle()
         assertEquals(listOf(3L, 1L), viewModel.events.value.map { it.id })
+
+        collectorJob.cancel()
     }
 
     private fun event(id: Long, date: String): EventResponse {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ retrofit = "2.11.0"
 okhttp = "4.12.0"
 gson = "2.11.0"
 coroutines = "1.8.1"
+coroutinesTest = "1.8.1"
 viewmodel = "2.10.0"
 securityCrypto = "1.1.0-alpha06"
 
@@ -38,6 +39,7 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhtt
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "viewmodel" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 


### PR DESCRIPTION
This pull request introduces comprehensive UI test coverage for several Compose screens and enhances the flexibility and testability of key repository and UI components. The most significant changes include the addition of new Android UI tests, refactoring repositories for easier mocking, and improvements to the `DashboardScreen` and `HomeScreen` composables to support better testability and user experience.

**New Android UI Tests:**

- Added instrumented Compose UI tests for `HomeScreen`, `DashboardScreen`, `AddEditEventDialog`, and `EventDetailScreen`, covering UI rendering, user interactions, and callback invocations. These tests use fake repositories and verify key behaviors like filtering, sorting, and reservation actions. [[1]](diffhunk://#diff-9cb0638dc51daf5a9e54aca4a5520565367363c447b929f1e36b82f6e1434ab9R1-R122) [[2]](diffhunk://#diff-d13084e5e018b4e1c71b29b462c89fa9a597e5a8cc5709c41f65d248f781f6a1R1-R65) [[3]](diffhunk://#diff-fd6d9e3b161fbff216e7521cea8ab903cb8731fccc9a37beb4cd6eb4064a30f2R1-R83) [[4]](diffhunk://#diff-e607632d4a66a12da3279a8d92983bd75c65fcf0bce37b4fd15a8e28f8d60711R1-R142)

**Repository Refactoring for Testability:**

- Changed `EventRepository` and `AdminRepository` classes from regular to `open` classes and made their API methods `open`, allowing them to be easily subclassed and mocked in tests. [[1]](diffhunk://#diff-f09902380867c1b11a42167bf4b69e0524fc7348496974dfe485dedc053e92ccL7-R27) [[2]](diffhunk://#diff-507ba03746f799a0af6cee4eda8b27b8faa64be39dabf061e62f86617aa3652bL7-R19)

**Dashboard and Home Screen Improvements:**

- Refactored `DashboardScreen` to accept `homeContent` and `reservationsContent` composable lambdas as parameters, enabling injection of test content and improving composability. [[1]](diffhunk://#diff-273a3c8cae196a2581061b4b0f133bfd3d6ed7962ed46bec0202f323c379761aL43-R53) [[2]](diffhunk://#diff-273a3c8cae196a2581061b4b0f133bfd3d6ed7962ed46bec0202f323c379761aL105-R119)
- Enhanced `HomeScreen` with date sort order filter chips ("Ascending"/"Descending") and wired them to a new `dateSortOrder` state in the `HomeViewModel`, allowing users to sort events by date. [[1]](diffhunk://#diff-699fb48a77a4a4d70f2d68420b526d48f9671aa9f1922956fba188958c8aa251R56) [[2]](diffhunk://#diff-699fb48a77a4a4d70f2d68420b526d48f9671aa9f1922956fba188958c8aa251R136-R149) [[3]](diffhunk://#diff-fdaff7571f674af2f9e4179b532da0302712553eb7bbb3a91ec9a3b8ad1cb643R31-R43)

**ViewModel and Sorting Logic:**

- Added `dateSortOrder` state to `HomeViewModel` and updated the event list transformation to sort events by date according to the selected order. [[1]](diffhunk://#diff-fdaff7571f674af2f9e4179b532da0302712553eb7bbb3a91ec9a3b8ad1cb643R8) [[2]](diffhunk://#diff-fdaff7571f674af2f9e4179b532da0302712553eb7bbb3a91ec9a3b8ad1cb643R31-R43)

**Test Dependency Update:**

- Added `kotlinx.coroutines.test` as a test dependency to support coroutine testing in the new UI test classes.